### PR TITLE
Replace sidebar branding and redesign client modal

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -25,9 +25,11 @@ a{color:inherit; text-decoration:none}
   border-right:1px solid rgba(255,255,255,.06);
 }
 .brand{display:flex; align-items:center; gap:12px; margin-bottom:18px}
+.logo-only{justify-content:center}
 .logo{width:38px; height:38px; border-radius:12px; background:linear-gradient(135deg, var(--accent) 0%, #3b82f6 100%); box-shadow: var(--shadow)}
 .brand h1{font-size:18px; margin:0}
 .sub{font-size:12px; color:var(--muted); margin:0 0 18px}
+.brand-logo{max-width:100%; height:auto; display:block}
 .nav{display:flex; flex-direction:column; gap:8px; margin-top:8px}
 .nav a{
   display:flex; align-items:center; gap:10px; padding:12px 12px; border-radius:12px;
@@ -84,7 +86,13 @@ td{padding:10px}
 /* MODAL */
 .modal{display:none;position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,.6);align-items:center;justify-content:center;z-index:1000}
 .modal.show{display:flex}
-.modal-content{background:var(--panel);padding:20px;border-radius:var(--radius);position:relative;box-shadow:var(--shadow);max-width:400px;width:90%}
+.modal-content{background:var(--panel);padding:20px;border-radius:var(--radius);position:relative;box-shadow:var(--shadow);max-width:600px;width:90%}
+.client-details{display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:12px;margin:12px 0 20px}
+.info-box{background:var(--panel);border:1px solid rgba(255,255,255,.08);border-radius:12px;padding:10px 12px;box-shadow:0 2px 6px rgba(0,0,0,.3)}
+.info-box .label{display:block;font-size:12px;color:var(--muted);margin-bottom:4px}
+.info-box.notes{grid-column:1/-1}
+.info-box.notes p{margin:0}
+.invoice-btn{display:block;width:100%;margin-bottom:20px}
 .modal-content .close{position:absolute;top:8px;right:12px;background:none;border:0;color:var(--text);font-size:20px;cursor:pointer}
 section{animation:fade .2s ease}
 @keyframes fade{from{opacity:0; transform:translateY(4px)} to{opacity:1; transform:none}}

--- a/clients.html
+++ b/clients.html
@@ -15,12 +15,8 @@
 <div class="app">
   <!-- SIDEBAR -->
   <aside class="side">
-    <div class="brand">
-      <div class="logo"></div>
-      <div class="txt">
-        <h1>ZAtech CRM</h1>
-        <p class="sub">Internal Portal</p>
-      </div>
+    <div class="brand logo-only">
+      <img src="./assets/img/zatech-logo.png" alt="ZAtech CRM" class="brand-logo" />
     </div>
     <nav class="nav" id="nav">
       <a href="./index.html"><span>🏠</span><span class="txt">Dashboard</span></a>
@@ -69,13 +65,15 @@
   <div class="modal-content">
     <button class="close">&times;</button>
     <h3 id="client-name"></h3>
-    <div class="muted" id="client-email"></div>
-    <p><strong>Phone:</strong> <span id="client-phone"></span></p>
-    <p><strong>Country:</strong> <span id="client-country"></span></p>
-    <p><strong>Joined:</strong> <span id="client-joined"></span></p>
-    <p><strong>Status:</strong> <span id="client-status"></span></p>
-    <p><strong>Notes:</strong></p>
-    <p id="client-notes"></p>
+    <div class="client-details">
+      <div class="info-box"><span class="label">Phone</span><span id="client-phone"></span></div>
+      <div class="info-box"><span class="label">Email</span><span id="client-email"></span></div>
+      <div class="info-box"><span class="label">Country</span><span id="client-country"></span></div>
+      <div class="info-box"><span class="label">Joined</span><span id="client-joined"></span></div>
+      <div class="info-box"><span class="label">Status</span><span id="client-status"></span></div>
+      <div class="info-box notes"><span class="label">Notes</span><p id="client-notes"></p></div>
+    </div>
+    <button class="btn invoice-btn" onclick="alert('Viewing latest invoice...')">View Latest Invoice</button>
     <h4>Recent Invoices</h4>
     <table id="client-invoices" style="margin-top:10px">
       <thead><tr><th>#</th><th>Date</th><th>Total</th><th>Status</th></tr></thead>


### PR DESCRIPTION
## Summary
- Add ZAtech logo to sidebar reference
- Expand client modal with card-style info boxes and invoice CTA
- Remove placeholder logo asset to allow user-supplied file

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a595f5f08c8324a4ce560099e25f1e