### PR TITLE
feat: refresh branding and expand client modal

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,5 +1,5 @@
 :root{
-  --bg:#0b1320;
+  --bg:#0e1730;
   --panel:#0f1b31;
   --soft:#121f3a;
   --muted:#8ea3c7;
@@ -14,7 +14,7 @@
 html,body{height:100%}
 body{
   margin:0; font-family:Inter,system-ui,Segoe UI,Roboto,Arial,sans-serif;
-  background: radial-gradient(1200px 600px at 20% -10%, #10264b 0%, transparent 60%), var(--bg);
+  background: radial-gradient(1200px 600px at 20% -10%, #163768 0%, transparent 60%), var(--bg);
   color:var(--text); line-height:1.4;
 }
 a{color:inherit; text-decoration:none}
@@ -24,18 +24,8 @@ a{color:inherit; text-decoration:none}
   position:sticky; top:0; height:100dvh; padding:28px 18px; background:linear-gradient(180deg, #0e1a30 0%, #0b1425 100%);
   border-right:1px solid rgba(255,255,255,.06);
 }
-.brand{display:flex; align-items:center; gap:12px; margin-bottom:18px}
-.logo-only{justify-content:center}
-.logo{width:35px; height:35px; border-radius:12px; background:linear-gradient(135deg, var(--accent) 0%, #3b82f6 100%); box-shadow: var(--shadow)}
-.logo-img {
-  width: 100px;   /* or whatever you want */
-  height: auto;   /* keeps proportions */
-  display: block;
-}
-
-.brand h1{font-size:18px; margin:0}
-.sub{font-size:12px; color:var(--muted); margin:0 0 18px}
-.brand-logo{max-width:80%; height:auto; display:block; margin-right: auto}
+.brand{display:flex; align-items:center; gap:12px; margin-bottom:18px; justify-content:flex-start}
+.brand-logo{width:120px; height:auto; display:block}
 .nav{display:flex; flex-direction:column; gap:8px; margin-top:8px}
 .nav a{
   display:flex; align-items:center; gap:10px; padding:12px 12px; border-radius:12px;
@@ -51,9 +41,10 @@ a{color:inherit; text-decoration:none}
 .search{flex:1; display:flex; gap:10px; align-items:center; background:var(--panel); padding:10px 12px; border-radius:12px; border:1px solid rgba(255,255,255,.06)}
 .search input{flex:1; background:transparent; border:0; outline:none; color:var(--text)}
 .btn{
-  padding:10px 14px; border-radius:12px; background:linear-gradient(135deg, var(--accent), var(--accent-2));
-  color:#081423; font-weight:700; border:0; box-shadow:var(--shadow); cursor:pointer;
+  padding:10px 14px; border-radius:12px; background:#2c8ecd; color:#f3f7ff; font-weight:700; border:none;
+  box-shadow:var(--shadow); cursor:pointer; transition:background .15s ease;
 }
+.btn:hover{background:#277fb9}
 /* CARD / GRID */
 .grid{display:grid; gap:14px}
 .grid.cols-4{grid-template-columns: repeat(4, minmax(0,1fr))}
@@ -81,8 +72,8 @@ tr td:first-child{border-left:1px solid rgba(255,255,255,.06); border-top-left-r
 tr td:last-child{border-right:1px solid rgba(255,255,255,.06); border-top-right-radius:10px; border-bottom-right-radius:10px}
 td{padding:10px}
 .row-actions{display:flex; gap:8px}
-.row-actions .mini{padding:6px 10px; border-radius:10px; background:#112a52; border:1px solid rgba(255,255,255,.08); color:#cfe2ff; font-size:12px; cursor:pointer; transition:transform .18s ease}
-.row-actions .mini:hover{transform:scale(1.05)}
+.row-actions .mini{padding:6px 10px; border-radius:10px; background:#2c8ecd; border:none; color:#f3f7ff; font-size:12px; cursor:pointer; transition:transform .18s ease, background .15s}
+.row-actions .mini:hover{transform:scale(1.05); background:#277fb9}
 /* PILLTABS */
 .pilltabs{display:flex; gap:8px; margin-bottom:10px}
 .pilltabs .pill{padding:8px 12px; border-radius:999px; border:1px solid rgba(255,255,255,.08); color:#cfe2ff; background:#10254a; cursor:pointer}
@@ -92,13 +83,15 @@ td{padding:10px}
 /* MODAL */
 .modal{display:none;position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,.6);align-items:center;justify-content:center;z-index:1000}
 .modal.show{display:flex}
-.modal-content{background:var(--panel);padding:20px;border-radius:var(--radius);position:relative;box-shadow:var(--shadow);max-width:600px;width:90%}
+.modal-content{background:var(--panel);padding:20px;border-radius:var(--radius);position:relative;box-shadow:var(--shadow);width:min(980px,96vw)}
 .client-details{display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:12px;margin:12px 0 20px}
 .info-box{background:var(--panel);border:1px solid rgba(255,255,255,.08);border-radius:12px;padding:10px 12px;box-shadow:0 2px 6px rgba(0,0,0,.3)}
 .info-box .label{display:block;font-size:12px;color:var(--muted);margin-bottom:4px}
 .info-box.notes{grid-column:1/-1}
 .info-box.notes p{margin:0}
-.invoice-btn{display:block;width:100%;margin-bottom:20px}
+.section-divider{border-top:1px solid rgba(255,255,255,.08);margin-top:12px;padding-top:12px}
+#client-name{font-size:20px}
+#clients .row-actions .mini{padding:8px 14px;font-size:13px}
 .modal-content .close{position:absolute;top:8px;right:12px;background:none;border:0;color:var(--text);font-size:20px;cursor:pointer}
 section{animation:fade .2s ease}
 @keyframes fade{from{opacity:0; transform:translateY(4px)} to{opacity:1; transform:none}}

--- a/assets/js/clients.js
+++ b/assets/js/clients.js
@@ -7,22 +7,33 @@ document.addEventListener('DOMContentLoaded', () => {
       const name = btn.closest('tr').children[0].textContent.trim();
       const data = clientsData[name];
       if (!data) return;
-      modal.querySelector('#client-name').textContent = data.name;
-      modal.querySelector('#client-email').textContent = data.email;
-      modal.querySelector('#client-phone').textContent = data.phone;
-      modal.querySelector('#client-country').textContent = data.country;
-      modal.querySelector('#client-joined').textContent = data.joined;
-      modal.querySelector('#client-status').textContent = data.status;
-      modal.querySelector('#client-notes').textContent = data.notes;
+      modal.querySelector('#client-name').textContent = data.name || '—';
+      modal.querySelector('#client-contact').textContent = data.contactName || '—';
+      modal.querySelector('#client-email').textContent = data.email || '—';
+      modal.querySelector('#client-phone').textContent = data.phone || '—';
+      modal.querySelector('#client-country').textContent = data.country || '—';
+      modal.querySelector('#client-joined').textContent = data.joined || '—';
+      modal.querySelector('#client-status').textContent = data.status || '—';
+      modal.querySelector('#client-address').textContent = data.address || '—';
+      modal.querySelector('#client-sector').textContent = data.sector || '—';
+      modal.querySelector('#client-notes').textContent = data.notes || '—';
       const tbody = modal.querySelector('#client-invoices tbody');
       tbody.innerHTML = '';
       data.invoices.forEach(inv => {
         const tr = document.createElement('tr');
-        tr.innerHTML = `<td>${inv.id}</td><td>${inv.date}</td><td>${inv.total}</td><td>${inv.status}</td>`;
+        tr.innerHTML = `<td>${inv.id}</td><td>${inv.date}</td><td>${inv.total}</td><td>${inv.status}</td><td class="row-actions"><button class="mini view-invoice" data-invoice="${inv.id}">View →</button></td>`;
         tbody.appendChild(tr);
       });
       modal.classList.add('show');
     });
+  });
+
+  modal.querySelector('#client-invoices tbody').addEventListener('click', (e) => {
+    const btn = e.target.closest('button[data-invoice]');
+    if (!btn) return;
+    const invoiceId = btn.dataset.invoice;
+    closeModal();
+    location.href = './invoices.html#' + invoiceId;
   });
 
   modal.addEventListener('click', (e) => {

--- a/calendar.html
+++ b/calendar.html
@@ -14,11 +14,7 @@
   <!-- SIDEBAR -->
   <aside class="side">
     <div class="brand">
-      <div class="logo"></div>
-      <div class="txt">
-        <h1>ZAtech CRM</h1>
-        <p class="sub">Internal Portal</p>
-      </div>
+      <img src="./assets/img/zatech-logo.png" alt="ZAtech Logo" class="brand-logo" />
     </div>
     <nav class="nav" id="nav">
       <a href="./index.html"><span>🏠</span><span class="txt">Dashboard</span></a>

--- a/clients.html
+++ b/clients.html
@@ -15,8 +15,8 @@
 <div class="app">
   <!-- SIDEBAR -->
   <aside class="side">
-    <div class="brand logo-only">
-      <img src="./assets/img/zatech-logo.png" alt="ZAtech CRM" class="brand-logo" />
+    <div class="brand">
+      <img src="./assets/img/zatech-logo.png" alt="ZAtech Logo" class="brand-logo" />
     </div>
     <nav class="nav" id="nav">
       <a href="./index.html"><span>🏠</span><span class="txt">Dashboard</span></a>
@@ -50,11 +50,11 @@
           <button class="pill">Paused</button>
         </div>
         <table>
-          <thead><tr><th>Client</th><th>Contact</th><th>Joined</th><th>Country</th><th>Invoices</th><th></th></tr></thead>
+          <thead><tr><th>Client</th><th>Contact</th><th>Contact Name</th><th>Phone</th><th>Joined</th><th>Country</th><th>Invoices</th><th></th></tr></thead>
           <tbody>
-            <tr><td>Acme LLC</td><td>nora@acme.com</td><td>2024-03-11</td><td>UAE</td><td>14</td><td class="row-actions"><button class="mini">Open</button></td></tr>
-            <tr><td>Riada Co</td><td>ops@riada.co</td><td>2023-09-02</td><td>JO</td><td>21</td><td class="row-actions"><button class="mini">Open</button></td></tr>
-            <tr><td>Nasma Group</td><td>it@nasma.com</td><td>2022-11-19</td><td>SA</td><td>9</td><td class="row-actions"><button class="mini">Open</button></td></tr>
+            <tr><td>Acme LLC</td><td>nora@acme.com</td><td>Nora</td><td>+971-555-1234</td><td>2024-03-11</td><td>UAE</td><td>14</td><td class="row-actions"><button class="mini">More Info →</button></td></tr>
+            <tr><td>Riada Co</td><td>ops@riada.co</td><td>Operations</td><td>+962-6-555-2345</td><td>2023-09-02</td><td>JO</td><td>21</td><td class="row-actions"><button class="mini">More Info →</button></td></tr>
+            <tr><td>Nasma Group</td><td>it@nasma.com</td><td>IT</td><td>+966-5-555-3456</td><td>2022-11-19</td><td>SA</td><td>9</td><td class="row-actions"><button class="mini">More Info →</button></td></tr>
           </tbody>
         </table>
       </div>
@@ -66,19 +66,23 @@
     <button class="close">&times;</button>
     <h3 id="client-name"></h3>
     <div class="client-details">
-      <div class="info-box"><span class="label">Phone</span><span id="client-phone"></span></div>
+      <div class="info-box"><span class="label">Contact Name</span><span id="client-contact"></span></div>
+      <div class="info-box"><span class="label">Phone Number</span><span id="client-phone"></span></div>
       <div class="info-box"><span class="label">Email</span><span id="client-email"></span></div>
       <div class="info-box"><span class="label">Country</span><span id="client-country"></span></div>
       <div class="info-box"><span class="label">Joined</span><span id="client-joined"></span></div>
       <div class="info-box"><span class="label">Status</span><span id="client-status"></span></div>
+      <div class="info-box"><span class="label">Address</span><span id="client-address"></span></div>
+      <div class="info-box"><span class="label">Sector</span><span id="client-sector"></span></div>
       <div class="info-box notes"><span class="label">Notes</span><p id="client-notes"></p></div>
     </div>
-    <button class="btn invoice-btn" onclick="alert('Viewing latest invoice...')">View Latest Invoice</button>
-    <h4>Recent Invoices</h4>
-    <table id="client-invoices" style="margin-top:10px">
-      <thead><tr><th>#</th><th>Date</th><th>Total</th><th>Status</th></tr></thead>
-      <tbody></tbody>
-    </table>
+    <div class="section-divider">
+      <h4>Recent Invoices</h4>
+      <table id="client-invoices" style="margin-top:10px">
+        <thead><tr><th>#</th><th>Date</th><th>Total</th><th>Status</th><th></th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </div>
   </div>
 </div>
 </body>

--- a/dues.html
+++ b/dues.html
@@ -14,11 +14,7 @@
   <!-- SIDEBAR -->
   <aside class="side">
     <div class="brand">
-      <div class="logo"></div>
-      <div class="txt">
-        <h1>ZAtech CRM</h1>
-        <p class="sub">Internal Portal</p>
-      </div>
+      <img src="./assets/img/zatech-logo.png" alt="ZAtech Logo" class="brand-logo" />
     </div>
     <nav class="nav" id="nav">
       <a href="./index.html"><span>🏠</span><span class="txt">Dashboard</span></a>

--- a/expenses.html
+++ b/expenses.html
@@ -14,11 +14,7 @@
   <!-- SIDEBAR -->
   <aside class="side">
     <div class="brand">
-      <div class="logo"></div>
-      <div class="txt">
-        <h1>ZAtech CRM</h1>
-        <p class="sub">Internal Portal</p>
-      </div>
+      <img src="./assets/img/zatech-logo.png" alt="ZAtech Logo" class="brand-logo" />
     </div>
     <nav class="nav" id="nav">
       <a href="./index.html"><span>🏠</span><span class="txt">Dashboard</span></a>

--- a/index.html
+++ b/index.html
@@ -14,11 +14,7 @@
   <!-- SIDEBAR -->
   <aside class="side">
     <div class="brand">
-      <div class="logo"></div>
-      <div class="txt">
-        <h1>ZAtech CRM</h1>
-        <p class="sub">Internal Portal</p>
-      </div>
+      <img src="./assets/img/zatech-logo.png" alt="ZAtech Logo" class="brand-logo" />
     </div>
     <nav class="nav" id="nav">
       <a href="./index.html"><span>🏠</span><span class="txt">Dashboard</span></a>

--- a/invoices.html
+++ b/invoices.html
@@ -16,11 +16,7 @@
   <!-- SIDEBAR -->
   <aside class="side">
     <div class="brand">
-      <div class="logo"></div>
-      <div class="txt">
-        <h1>ZAtech CRM</h1>
-        <p class="sub">Internal Portal</p>
-      </div>
+      <img src="./assets/img/zatech-logo.png" alt="ZAtech Logo" class="brand-logo" />
     </div>
     <nav class="nav" id="nav">
       <a href="./index.html"><span>🏠</span><span class="txt">Dashboard</span></a>

--- a/opps.html
+++ b/opps.html
@@ -14,11 +14,7 @@
   <!-- SIDEBAR -->
   <aside class="side">
     <div class="brand">
-      <div class="logo"></div>
-      <div class="txt">
-        <h1>ZAtech CRM</h1>
-        <p class="sub">Internal Portal</p>
-      </div>
+      <img src="./assets/img/zatech-logo.png" alt="ZAtech Logo" class="brand-logo" />
     </div>
     <nav class="nav" id="nav">
       <a href="./index.html"><span>🏠</span><span class="txt">Dashboard</span></a>

--- a/revenue.html
+++ b/revenue.html
@@ -14,11 +14,7 @@
   <!-- SIDEBAR -->
   <aside class="side">
     <div class="brand">
-      <div class="logo"></div>
-      <div class="txt">
-        <h1>ZAtech CRM</h1>
-        <p class="sub">Internal Portal</p>
-      </div>
+      <img src="./assets/img/zatech-logo.png" alt="ZAtech Logo" class="brand-logo" />
     </div>
     <nav class="nav" id="nav">
       <a href="./index.html"><span>🏠</span><span class="txt">Dashboard</span></a>

--- a/schedule.html
+++ b/schedule.html
@@ -14,11 +14,7 @@
   <!-- SIDEBAR -->
   <aside class="side">
     <div class="brand">
-      <div class="logo"></div>
-      <div class="txt">
-        <h1>ZAtech CRM</h1>
-        <p class="sub">Internal Portal</p>
-      </div>
+      <img src="./assets/img/zatech-logo.png" alt="ZAtech Logo" class="brand-logo" />
     </div>
     <nav class="nav" id="nav">
       <a href="./index.html"><span>🏠</span><span class="txt">Dashboard</span></a>

--- a/settings.html
+++ b/settings.html
@@ -14,11 +14,7 @@
   <!-- SIDEBAR -->
   <aside class="side">
     <div class="brand">
-      <div class="logo"></div>
-      <div class="txt">
-        <h1>ZAtech CRM</h1>
-        <p class="sub">Internal Portal</p>
-      </div>
+      <img src="./assets/img/zatech-logo.png" alt="ZAtech Logo" class="brand-logo" />
     </div>
     <nav class="nav" id="nav">
       <a href="./index.html"><span>🏠</span><span class="txt">Dashboard</span></a>


### PR DESCRIPTION
## Summary
- swap sidebar branding for a new ZAtech logo on every page
- lighten dark theme and unify button styling with secondary color
- extend clients table and modal with more fields and invoice deep links

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5a02891b8832488a7c1fe1fc6eef9